### PR TITLE
Fixed issue when custom cyberchef_url was given (assumed subpath)

### DIFF
--- a/chepy/core.py
+++ b/chepy/core.py
@@ -627,14 +627,14 @@ class ChepyCore(object):
         if magic:
             url = urljoin(
                 cyberchef_url,
-                "/CyberChef/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}".format(
+                "/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}".format(
                     data.decode()
                 ),
             )
         else:
             url = urljoin(
                 cyberchef_url,
-                "/CyberChef/#recipe=From_Hex('None')&input={}".format(data.decode()),
+                "/#recipe=From_Hex('None')&input={}".format(data.decode()),
             )
         webbrowser.open_new_tab(url)
         return None


### PR DESCRIPTION
Hosting of the CyberChef page can be done at many subpaths, including / (root):

E.g. the following should be allowed
www.example.com/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}
www.example.com/internal/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}

Currently the following happens when a custom page is given:
www.example.com/CyberChef/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}
www.example.com/internal/CyberChef/#recipe=From_Hex('None')Magic(3,false,false,'')&input={}