### PR TITLE
Always .load_file as binary

### DIFF
--- a/chepy/core.py
+++ b/chepy/core.py
@@ -741,12 +741,8 @@ class ChepyCore(object):
             >>> c.load_file() # this will load the file content into the state
         """
         path = pathlib.Path(self.state).expanduser().absolute()
-        try:
-            with open(path, "r") as f:
-                self.states[self._current_index] = f.read()
-        except UnicodeDecodeError:
-            with open(path, "rb") as f:
-                self.states[self._current_index] = bytearray(f.read())
+        with open(path, "rb") as f:
+            self.states[self._current_index] = bytearray(f.read())
         return self
 
     def write_to_file(self, path: str, as_binary: bool = False) -> None:


### PR DESCRIPTION
Previously, .load_file would have tried to load files by allowing Python to decide what encoding to use. This broke some functions (md5) as the contents of the file would be changed my python upon reading (it would try and decode text files automatically and if it failed revert to binary mode)